### PR TITLE
Update InsertString.cs

### DIFF
--- a/FluentStrings/Actions/Insert/Auxiliary/InsertString.cs
+++ b/FluentStrings/Actions/Insert/Auxiliary/InsertString.cs
@@ -1,17 +1,18 @@
+using System.Text;
 ﻿namespace dokas.FluentStrings.Actions.Insert
 {
     public class InsertString
     {
-        private readonly string _source;
+        private readonly StringBuilder _source;
         private readonly string _insertion;
 
-        internal InsertString(string source, string insertion)
+        internal InsertString(StringBuilder source, string insertion)
         {
             _source = source;
             _insertion = insertion;
         }
 
-        internal string Source { get { return _source; } }
+        internal StringBuilder Source { get { return _source; } }
         internal string Insertion { get { return _insertion; } }
 
         public static implicit operator string(InsertString insertString)
@@ -23,7 +24,7 @@
         {
             return (_source == null && _insertion == null)
                 ? null
-                : _insertion + _source;
+                : _insertion + _source.ToString();
         }
     }
 }


### PR DESCRIPTION
Hi! Maybe you can use StringBuilder better than string in the source. Because strings are inmutable, and when you add string x + string y, you are creating a copy and wasting memory, but using StringBuilder, this doesn´t happen.
Think about it! If you decide it, I can help you to change it! ;) 
Add me if you want, oscarbralo@gmail.com
